### PR TITLE
Alpha 16-c. newSession workflow, Caching in file-service

### DIFF
--- a/src/annoweb-audio.js
+++ b/src/annoweb-audio.js
@@ -5,6 +5,14 @@
     'use strict';
     angular
         .module('annoweb-audio', [])
+        .directive('ngRecord', function() {
+            return {
+                restrict: 'E',
+                templateUrl: 'views/templates/record-template.html',
+                controller: newRecordDirectiveController,
+                controllerAs: 'nrCtrl'
+            };
+        })
         .directive("ngRespeak", function() {
             return {
                 restrict: "E",
@@ -13,10 +21,234 @@
                 controllerAs: 'rCtrl'
             };
         });
+    
+    var newRecordDirectiveController = function ($scope, $location, $window, loginService, audioService, dataService, fileService, $sce) {
+        var vm = this;
+        var rec;
+
+        var doublemode = true;
+
+        $scope.recording = '';
+
+        if (doublemode) {vm.context = new AudioContext();}
+
+        vm.wsRecord = Object.create(WaveSurfer);
+        vm.wsRecord.init({
+            container: "#respeakRecord",
+            normalize: false,
+            scrollParent: true,
+            cursorWidth: 0
+        });
+
+        // Init Microphone plugin
+        var microphone = Object.create(WaveSurfer.Microphone);
+        microphone.init({
+            wavesurfer: vm.wsRecord
+        });
+        microphone.on('deviceReady', function() {
+            console.info('Device ready!');
+            if (doublemode) {
+                microphone.play();
+                $scope.$apply(function() {
+                    $scope.recordClass = 'activespeaker';
+                });
+            } else {
+                rec = new Recorder(microphone.mediaStreamSource,{numChannels: 1});
+            }
+        });
+        microphone.on('deviceError', function(code) {
+            console.warn('Device error: ' + code);
+        });
+
+        microphone.start();
+
+        if (doublemode) {
+            // start our own audio context for recorder.js. Because calling pause() on the wavesurfer microphone
+            // plugin disconnects the node, we'll end up with an empty file!
+            navigator.mediaDevices.getUserMedia({video: false, audio: true})
+                .then(function (mediastream) {
+                    vm.streamsource = vm.context.createMediaStreamSource(mediastream);
+                    rec = new Recorder(vm.streamsource, {numChannels: 1});
+                })
+                .catch(function (feh) {
+                    console.log('audio spaz', feh);
+                });
+        }
+
+        function createDownsampledLink(targetSampleRate) {
+            rec.getBuffer(function(buf){
+                vm.recordDurMsec = Math.floor(buf[0].length / (microphone.micContext.sampleRate/1000));
+                console.log('rt', vm.recordDurMsec);
+                
+                audioService.resampleAudioBuffer(microphone.micContext,buf,targetSampleRate,function(thinggy){
+                    //var url = thinggy.getFile();
+                    //$scope.recording=$sce.trustAsResourceUrl(url);
+                    
+                    var blob = thinggy.getFile();
+                    fileService.createFile(loginService.getLoggedinUserId(), blob).then(function(url) {
+                        vm.recordUrl = url;
+                        $scope.recording=$sce.trustAsResourceUrl(url);
+                    });
+                });
+            });
+        }
+
+        vm.hasrecording = function() {
+            return $scope.recording !== '';
+        };
+
+        
+        vm.isrecording = false;
+        $scope.recordClass = 'inactivespeaker'; // becomes activespeaker when user permits microphone
+
+        function spacedown () {
+            if(!vm.recordUrl) {
+                if (!vm.isrecording) {
+                    console.log('starting record');
+                    rec.record();
+
+                    $scope.recordClass = 'activerecord';
+                    vm.isrecording=true;
+                    $scope.$apply();
+                } else {
+                    console.log('stopping record');
+                    rec.stop();
+                    vm.wsRecord.empty();
+
+                    $scope.recordClass = 'activespeaker';
+                    vm.isrecording = false;
+                    $scope.$apply();
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        // We must use this because the underlying library (mousetrap) used by angular-hotkeys does
+        // not provide any way to handle keys that are held down, e.g. ignoring repeated events.
+        //
+        var listener = new $window.keypress.Listener();
+        listener.register_combo({
+            "keys"              : 'space',
+            "on_keydown"        :spacedown,
+            "prevent_repeat"    :true
+        });
+
+        vm.check = function() {
+            // Disable/Clean microphone/recorder
+            $scope.recordClass = 'inactivespeaker';
+            microphone.pause();
+            if(vm.isRecording) {
+                rec.stop();
+                vm.wsRecord.empty();
+                
+                vm.isrecording = false;
+                $scope.$apply();
+            }
+            
+            // File created and url is stored
+            createDownsampledLink(22050);
+            //createDownsampledLink(48000);
+        };
+        
+        vm.isMetaEmpty = function() {
+            return vm.recordUrl === '' || vm.selectedLanguages.length === 0 || vm.selectedTitles.length === 0;
+        };
+        
+        vm.save = function() {
+            var fileObjId;
+            dataService.get('user', loginService.getLoggedinUserId()).then(function(userObj) {
+                // Add fileObj to user metadata
+                var fileObj = {
+                    url: vm.recordUrl,
+                    type: 'audio/wav'
+                };
+                
+                fileObjId = userObj.addUserFile(fileObj);
+                return userObj.save();
+            }).then(function() {
+                // Create new session metadata
+                var sessionData = {};
+                sessionData.names = vm.selectedTitles;
+                sessionData.creatorId = loginService.getLoggedinUserId();
+                sessionData.source = {
+                    recordingFileId: fileObjId,
+                    created: Date.now(),
+                    duration: vm.recordDurMsec,
+                    langIds: vm.selectedLanguages.map(function(lang) { return lang.id; })
+                };
+                
+                return dataService.setSession(loginService.getLoggedinUserId(), sessionData);
+            }).then(function(sessionId) {
+                // Recording file and session metadata are both created
+                vm.isCompleted = true;
+                
+                $location.path('session/'+sessionId);
+            });
+        };
+
+        vm.reset = function() {
+            rec.stop();
+            rec.clear();
+            $scope.recordClass = 'inactivespeaker';
+            $scope.recording = '';
+        };
+
+        $scope.$on('$destroy', function() {
+            listener.destroy();
+            if(rec)
+                rec.clear();
+        });
+        
+        $window.onbeforeunload = function() {
+            // When a file is created but metadata is not
+            if(vm.recordUrl && !vm.isCompleted)
+                fileService.deleteFile(vm.recordUrl);
+        };
+        
+        /////////////////////////////// 
+        vm.isCompleted = false;
+        vm.recordUrl = '';
+        vm.recordDurMsec = 0;
+        
+        vm.selectedTitles = [];
+        vm.selectedLanguages = [];
+        vm.langFilterOn = true;
+        
+        vm.langPlaceholder = "Add languages";
+        vm.langSecPlaceholder = "Add more";
+        vm.titlePlaceholder = "Add titles";
+        vm.titleSecPlaceholder = "Add more";
+        
+        // Language input interface for session
+        fileService.getLanguages().then(function(langObjList) {
+            var langList = langObjList.map(function(langObj) {
+                return {
+                    id: langObj.Id,
+                    name: langObj.Ref_Name,
+                    value: langObj.Ref_Name.toLowerCase()
+                };
+            });
+            
+            vm.langQuerySearch = function(query) {
+                var results = [];
+                query = query.toLowerCase();
+                if(query) {
+                    results = langList.filter(function(lang) {
+                        return lang.value.indexOf(query) === 0;
+                    });
+                }
+                return results;
+            };
+        });
+
+    };
+    newRecordDirectiveController.$inject = ['$scope', '$location', '$window', 'loginService', 'audioService', 'dataService', 'fileService', '$sce'];
 
     var respeakDirectiveController = function ($scope, $window, $attrs, loginService, audioService, dataService, fileService, $sce) {
-        var rec;
         var vm = this;
+        var rec;
 
         var doublemode = true;
         vm.isplaying = false;
@@ -32,7 +264,7 @@
         if (doublemode) {vm.context = new AudioContext();}
 
         vm.segments = [];
-
+        
         vm.wsPlayback = Object.create(WaveSurfer);
         vm.wsPlayback.init({
             container: "#respeakPlayback",
@@ -189,6 +421,7 @@
 
         vm.save = function() {
             createDownsampledLink(22050);
+            //createDownsampledLink(48000);
         };
 
         vm.reset = function() {
@@ -223,7 +456,8 @@
             listener.destroy();
             vm.wsPlayback.destroy();
             vm.wsPlayback.destroy();
-            rec.clear();
+            if(rec)
+                rec.clear();
         });
 
     };

--- a/src/annoweb-commondirectives.js
+++ b/src/annoweb-commondirectives.js
@@ -49,6 +49,10 @@
         .directive("ngMetadata", function() {
             return {
                 restrict: "E",
+                scope: {
+                    userId: '@',
+                    sessionId: '@'
+                },
                 templateUrl: "views/templates/metadata-template.html",
                 controller: metadataController,
                 controllerAs: 'mCtrl'
@@ -140,8 +144,12 @@
         
             // load the requested session from the service and get the current users
             return dataService.get('session', $scope.sessionId);
+            
         }).then(function(sessionObj) {
-            var selectedIds = sessionObj.data.roles[$scope.role];
+            var selectedIds = [];
+            if(sessionObj.data.roles) {
+                selectedIds = sessionObj.data.roles[$scope.role];
+            }
             
             // onload populate the chips selector with existing (based on ids)
             $scope.selectedPeople = _.map(selectedIds, function(id) {
@@ -151,6 +159,8 @@
             // ordinary watch and ng-change don't work.
             $scope.$watchCollection('selectedPeople', function() {
                 var idList = _.pluck($scope.selectedPeople, 'id');
+                if(!sessionObj.data.roles)
+                    sessionObj.data.roles = {};
                 sessionObj.data.roles[$scope.role] = idList;
                 sessionObj.save();
             });
@@ -285,7 +295,7 @@
             AnnowebDialog.newMetdata();
         };
 
-        vm.defaultdisplay = ['Description','Location']
+        vm.defaultdisplay = ['Description','Location'];
 
         vm.details = [
             {

--- a/src/annoweb-viewcontrollers.js
+++ b/src/annoweb-viewcontrollers.js
@@ -10,7 +10,8 @@
         //.controller('homeController', ['$location', 'dataService', 'loginService', function($location, dataService, loginService) {
         .controller('homeController', ['$scope', '$location', 'dataService', 'loginService', function($scope, $location, dataService, loginService) {
             var vm = this;
-            vm.username = 'Unknown user';
+            var currentUserName = 'Unknown user';
+            vm.username = function() { return currentUserName; };
 
             vm.getLoginStatus = loginService.getLoginStatus;    //wrapper function for js primitive data binding
 
@@ -20,10 +21,9 @@
                 dataService.getSessionList(vm.currentUser._ID).then(function(sessionList) {
                     vm.sessionList = sessionList;
                 });
-/*                dataService.get('user', vm.currentUser._ID).then(function(userObj) {
-                        vm.username = userObj.data.names[0];
-                    }
-                );*/
+                dataService.get('user', vm.currentUser._ID).then(function(userObj) {
+                    currentUserName = userObj.data.names[0];       
+                });
             });
 
             vm.goStatus = function(sessionIndex) {
@@ -137,6 +137,12 @@
             };
 
         }])
+    
+        .controller('newSessionController', ['$location', 'loginService', 'dataService', function($location, loginService, dataService) {
+            // For now, new.html is just a container of ngRecord directive
+            var vm = this;
+            
+        }])
 
         .controller('statusController', ['$location', '$routeParams', 'loginService', 'dataService', function($location, $routeParams, loginService, dataService) {
             var vm = this;
@@ -147,9 +153,9 @@
             vm.userId = loginService.getLoggedinUserId();
             vm.sessionId = $routeParams.sessionId;
             
-            /*dataService.get('user', vm.userId).then(function(userObj) {
+            dataService.get('user', vm.userId).then(function(userObj) {
                 vm.userData = userObj.data;
-            });*/
+            });
             
             dataService.get('session', vm.sessionId).then(function(sessionObj){
                 vm.sessionData = sessionObj.data;

--- a/src/app.js
+++ b/src/app.js
@@ -51,6 +51,10 @@
                         templateUrl: 'views/home.html',
                         controller: 'homeController as hCtrl',
                     })
+                    .when('/new', {
+                        templateUrl: 'views/new.html',
+                        controller: 'newSessionController as nCtrl'
+                    })
                     .when('/session/:sessionId', {
                         templateUrl: 'views/status.html',
                         controller: 'statusController as sCtrl',

--- a/views/home.html
+++ b/views/home.html
@@ -5,7 +5,7 @@
 </md-toolbar>
 <md-content class="md-padding">
 
-    <p class="md-title inset">Welcome back <i>{{hCtrl.username}}.</i></p>
+    <p class="md-title inset">Welcome back <i>{{hCtrl.username()}}.</i></p>
 
         <md-list ng-if="hCtrl.getLoginStatus()">
             <md-list-item class="md-3-line" ng-repeat="session in hCtrl.sessionList" ng-click="hCtrl.goStatus($index)">

--- a/views/new.html
+++ b/views/new.html
@@ -1,33 +1,10 @@
-<h3>New Recording/project view</h3>
+<md-toolbar>
+    <div class="md-toolbar-tools">
+        <span class="md-headline"><A HREF="#/">Home</A> &nbsp;&gt;&nbsp New</span>
+    </div>
+</md-toolbar>
+<md-content class="md-padding" md-scroll-y>
 
-<p><b>Purpose</b>: Users see this view when they want to record a new file. The view is based on two steps: 1. Record basic metadata. 2. Select source (or record new)</p>
+    <ng-record source-id="1"></ng-record>
 
-<p><b>Design influence</b>: ?</p>
-
-<p><b>Navigation</b>: They get here from the home/landing page by selecting new. The user will then end up on the primary recording status page. </p>
-
-<md-content style="{background-color:lightgrey;}" flex class="md-whiteframe-2dp md-padding">
-
-    <h3>Dummy data</h3>
-
-    <p>Basic metadata input: Name, language. Tag selector.</p>
-    <A ui-sref="record">
-        <md-button class="md-raised">
-            <md-icon md-svg-icon="action:record_voice_over"></md-icon>
-            Begin recording
-        </md-button>
-    </a>
-    or
-    <A ui-sref="open">
-        <md-button class="md-raised">
-            <md-icon md-svg-icon="file:folder_open"></md-icon>
-            Import file
-        </md-button>
-    </a>
-
-    <p>
-        Having done this we end up <A ui-sref="status">here.</A>
-    </p>
 </md-content>
-
-<p>Notes: This page offers a jump off for two different activities but returns to the same view. The side-nav options jump directly to these activities.</p>

--- a/views/templates/record-template.html
+++ b/views/templates/record-template.html
@@ -1,0 +1,44 @@
+<div layout="row">
+    <div layout="column" flex="50" >
+        <md-chips ng-model="nrCtrl.selectedTitles"
+                  placeholder="{{nrCtrl.titlePlaceholder}}"
+                  secondary-placeholder="{{nrCtrl.titleSecPlaceholder}}">
+        </md-chips>
+        
+        <md-contact-chips ng-model="nrCtrl.selectedLanguages"
+                          md-contacts="nrCtrl.langQuerySearch($query)"
+                          md-contact-name="name"
+                          md-contact-email="id"
+                          md-require-match="true"
+                          md-highlight-flags="i"
+                          filter-selected="nrCtrl.langFilterOn"
+                          placeholder="{{nrCtrl.langPlaceholder}}"
+                          secondary-placeholder="{{nrCtrl.langSecPlaceholder}}">
+        </md-contact-chips>
+        
+        <md-button ng-disabled="nrCtrl.recordUrl" class="md-raised ng-class:{'nowrecording': nrCtrl.isrecording}" aria-label="Save" ng-click="nrCtrl.check()" >
+            <md-icon md-svg-icon="av:mic"></md-icon>
+            <span flex>Record</span>
+        </md-button>
+        
+        <div ng-if="nrCtrl.hasrecording()">
+            <audio controls ng-src="{{recording}}">
+            </audio>
+        </div>
+    </div>
+    <div flex="50" ng-class="recordClass" class="respeakwavesurfer" id="respeakRecord"></div>
+</div>
+
+<md-button class="md-raised" aria-label="Reset" ng-click="nrCtrl.reset()" >
+    <md-icon md-svg-icon="action:restore"></md-icon>
+    Reset
+</md-button>
+
+<md-button class="md-raised" aria-label="Check" ng-click="nrCtrl.check()" >
+    <md-icon md-svg-icon="content:save"></md-icon>
+    Check
+</md-button>
+<md-button ng-disabled="nrCtrl.isMetaEmpty()" class="md-raised" aria-label="Save" ng-click="nrCtrl.save()" >
+    <md-icon md-svg-icon="content:save"></md-icon>
+    Save
+</md-button>


### PR DESCRIPTION
- newSession workflow/route is created and can be accessed from home.html
- ngRecord directive is created and used in newSession workflow
  - Any multiple titles can be typed by an user
  - An user can type in a language out of the ISO-639 list
  - space-bar doesn't have to keep pressed for recording. Instead, each hit alternate record/pause
  - Check button will create a recording file and allow an user to review it
  - Save button is enabled after title, language, file are made by an user
  - Reload/Exit of the page cleans all relevant resources
  - File-service and Data-service is hooked up to make the recording file and metadata(lang, title) persist
- Caching is implemented in data-service
- The recording file is now saved with the wave type
- session data now has source field which keeps following information:
  - recordFileId: ID of the source recording file-metadata stored in user.files
  - langIds: ISO-639 language 3-alphabet IDs
  - created: the source recording file creation date
  - duration: the duration of the source recording file in msec.

```
source = {
  recordFileId,
  langIds,
  created,
  duration,
}
```
- Error fixes
  - ngMetadata directive error fix: wrong use of $scope
  - ngRespeak directive error fix: check if recorder is created before clean it
  - ngUserSelector directive error fix: check if session has roles filed before use it
  - homeController fix to show the current user's name
